### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -6,7 +6,7 @@ function init -a path --on-event init_git-flow
     end
   end
 
-  if not available __fish_git_branches
+  if not type -q __fish_git_branches
     echo "Error: git completion not found!" >&2; return 1
   end
 end


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
