### PR TITLE
init.fish: Use $fish_complete_path instead of hard coded prefixes

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,6 +1,7 @@
-for prefix in /usr /usr/local /opt/local
-  if test -f $prefix/share/fish/completions/git.fish
-    source $prefix/share/fish/completions/git.fish
+for prefix in $fish_complete_path
+  if not string match -e git-flow $prefix >/dev/null
+    and test -f $prefix/git.fish
+    source $prefix/git.fish
     break
   end
 end


### PR DESCRIPTION
plugin-git-flow breaks all git completions platforms that install fish somewhere outside of /usr, /usr/local or /opt/local.  Example: http://nixos.org

This PR uses the standard `$fish_complete_path`, filtering out any paths containing the string `git-flow`